### PR TITLE
Add gtk_chart_set_x_min, gtk_chart_set_y_min, and gtk_chart_get_x_max

### DIFF
--- a/demo/gtkchart-demo.c
+++ b/demo/gtkchart-demo.c
@@ -9,6 +9,8 @@
 #include <gtkchart.h>
 #include <adwaita.h>
 
+#define VIEWPORT_WIDTH 25  // Show 5 units of x-axis at a time
+
 static GtkChart *chart;
 static GMutex producer_mutex;
 
@@ -21,6 +23,12 @@ struct point_t
 static gboolean gui_chart_plot_thread(gpointer user_data)
 {
     struct point_t *point = user_data;
+
+    // Update the viewport to follow the latest data
+    if (point->x > gtk_chart_get_x_max(chart)) {
+        gtk_chart_set_x_min(chart, point->x - VIEWPORT_WIDTH);
+        gtk_chart_set_x_max(chart, point->x);
+    }
 
     gtk_chart_plot_point(chart, point->x, point->y);
 
@@ -42,7 +50,11 @@ static void activate_cb(GApplication *app, gpointer user_data)
     gtk_chart_set_label(chart, "Label");
     gtk_chart_set_x_label(chart, "X label [unit]");
     gtk_chart_set_y_label(chart, "Y label [unit]");
-    gtk_chart_set_x_max(chart, 100);
+
+    // Initial viewport setup
+    gtk_chart_set_x_min(chart, 0.0);
+    gtk_chart_set_x_max(chart, VIEWPORT_WIDTH);
+    gtk_chart_set_y_min(chart, 0.0);
     gtk_chart_set_y_max(chart, 10);
     gtk_chart_set_width(chart, 800);
 

--- a/demo/gtkchart-demo.c
+++ b/demo/gtkchart-demo.c
@@ -24,7 +24,7 @@ static gboolean gui_chart_plot_thread(gpointer user_data)
 {
     struct point_t *point = user_data;
 
-    // Update the viewport to follow the latest data
+    // Update x-axis viewport to follow the latest data
     if (point->x > gtk_chart_get_x_max(chart)) {
         gtk_chart_set_x_min(chart, point->x - VIEWPORT_WIDTH);
         gtk_chart_set_x_max(chart, point->x);
@@ -46,16 +46,16 @@ static void activate_cb(GApplication *app, gpointer user_data)
 
     chart = GTK_CHART(gtk_chart_new());
     gtk_chart_set_type(chart, GTK_CHART_TYPE_LINE);
-    gtk_chart_set_title(chart, "Sine signal, f(x) = 5 + 3sin(x)");
+    gtk_chart_set_title(chart, "Sine signal, f(x) = 3sin(x)");
     gtk_chart_set_label(chart, "Label");
     gtk_chart_set_x_label(chart, "X label [unit]");
     gtk_chart_set_y_label(chart, "Y label [unit]");
 
-    // Initial viewport setup
+    // Set fixed y-axis range to show complete sine wave
     gtk_chart_set_x_min(chart, 0.0);
     gtk_chart_set_x_max(chart, VIEWPORT_WIDTH);
-    gtk_chart_set_y_min(chart, 0.0);
-    gtk_chart_set_y_max(chart, 10);
+    gtk_chart_set_y_max(chart, 3.5);   // Above maximum of sine wave
+    gtk_chart_set_y_min(chart, -3.5);  // Below minimum of sine wave
     gtk_chart_set_width(chart, 800);
 
     // gtk_chart_set_color(chart, "text_color", "red");
@@ -80,10 +80,10 @@ static gpointer producer_function(gpointer user_data)
 
     g_mutex_lock(&producer_mutex);
 
-    // Plot demo sine signal
+    // Plot demo sine wave with negative values
     while (x < 100)
     {
-        y = 5.0 + 3.0*sin(x);
+        y = 3.0 * sin(x);  // Will oscillate between -3 and +3
         point.x = x;
         point.y = y;
         g_idle_add(gui_chart_plot_thread, &point);

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -69,6 +69,7 @@ EXPORT void gtk_chart_set_y_max(GtkChart *chart, double y_max);
 EXPORT void gtk_chart_set_x_min(GtkChart *chart, double x_min);
 EXPORT void gtk_chart_set_y_min(GtkChart *chart, double y_min);
 EXPORT double gtk_chart_get_x_max(GtkChart *chart);
+EXPORT double gtk_chart_get_y_min(GtkChart *chart);
 EXPORT void gtk_chart_set_width(GtkChart *chart, int width);
 EXPORT void gtk_chart_plot_point(GtkChart *chart, double x, double y);
 EXPORT void gtk_chart_set_value(GtkChart *chart, double value);
@@ -82,4 +83,3 @@ EXPORT bool gtk_chart_set_color(GtkChart *chart, char *name, char *color);
 EXPORT void gtk_chart_set_font(GtkChart *chart, const char *name);
 
 G_END_DECLS
-

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -66,6 +66,9 @@ EXPORT void gtk_chart_set_x_label(GtkChart *chart, const char *x_label);
 EXPORT void gtk_chart_set_y_label(GtkChart *chart, const char *y_label);
 EXPORT void gtk_chart_set_x_max(GtkChart *chart, double x_max);
 EXPORT void gtk_chart_set_y_max(GtkChart *chart, double y_max);
+EXPORT void gtk_chart_set_x_min(GtkChart *chart, double x_min);
+EXPORT void gtk_chart_set_y_min(GtkChart *chart, double y_min);
+EXPORT double gtk_chart_get_x_max(GtkChart *chart);
 EXPORT void gtk_chart_set_width(GtkChart *chart, int width);
 EXPORT void gtk_chart_plot_point(GtkChart *chart, double x, double y);
 EXPORT void gtk_chart_set_value(GtkChart *chart, double value);
@@ -79,3 +82,4 @@ EXPORT bool gtk_chart_set_color(GtkChart *chart, char *name, char *color);
 EXPORT void gtk_chart_set_font(GtkChart *chart, const char *name);
 
 G_END_DECLS
+


### PR DESCRIPTION
- Added `gtk_chart_set_x_min` and `gtk_chart_set_y_min` so you can specify the lower bounds of each axis.
- Added `gtk_chart_get_x_max` to let the demo track the highest X value.
- Updated the demo to only show the last N data points (e.g. 25), so you get a simple “moving window” view.