### PR TITLE
Refactor `gtk_chart_save_csv` introduce GError for error handling, new API `gtk_chart_get_points`

### DIFF
--- a/src/gtkchart.c
+++ b/src/gtkchart.c
@@ -928,6 +928,11 @@ EXPORT bool gtk_chart_save_csv(GtkChart *chart, const char *filename, GError **e
     return g_file_set_contents(filename, csv->str, csv->len, error);
 }
 
+EXPORT GSList * gtk_chart_get_points(GtkChart *chart)
+{
+  return chart->point_list;
+}
+
 EXPORT bool gtk_chart_save_png(GtkChart *chart, const char *filename, GError **error)
 {
     int width = gtk_widget_get_width (GTK_WIDGET(chart));

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -43,6 +43,8 @@
   #endif
 #endif
 
+typedef struct chart_point_t ChartPoint;
+
 G_BEGIN_DECLS
 
 #define GTK_TYPE_CHART (gtk_chart_get_type ())
@@ -77,6 +79,7 @@ EXPORT void gtk_chart_set_value_min(GtkChart *chart, double value);
 EXPORT void gtk_chart_set_value_max(GtkChart *chart, double value);
 EXPORT bool gtk_chart_save_csv(GtkChart *chart, const char *filename, GError **error);
 EXPORT bool gtk_chart_save_png(GtkChart *chart, const char *filename, GError **error);
+EXPORT GSList * gtk_chart_get_points(GtkChart *chart);
 EXPORT void gtk_chart_set_user_data(GtkChart *chart, void *user_data);
 EXPORT void * gtk_chart_get_user_data(GtkChart *chart);
 EXPORT bool gtk_chart_set_color(GtkChart *chart, char *name, char *color);


### PR DESCRIPTION
`gtk_chart_save_csv()` is designed as a high-level convenience function for saving chart data to a CSV file. Following common GLib and GNOME library practices—such as `g_key_file_save_to_file` in GLib itself or `json_generator_to_file()` in json-glib—this function wraps g_file_set_contents() internally:
![image](https://github.com/user-attachments/assets/e8f98fad-24f4-4ee5-9c16-86b9bbe49761)
![image](https://github.com/user-attachments/assets/02f8707b-17f3-415c-b9ab-a8dbe3889934)

For scenarios where the caller needs to manipulate or export chart data manually, a separate public API `gtk_chart_get_points()` is provided. This gives the user full access to the chart's data points for custom processing, without requiring them to reimplement the CSV logic themselves.

