### PR TITLE
Feature: add .clang-format & .editorconfig for code formatting enforcement

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+Language: C
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+ColumnLimit: 100
+ContinuationIndentWidth: 4
+
+AlignConsecutiveDeclarations: true
+AlignConsecutiveAssignments: true
+AlignTrailingComments: true
+
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+BreakBeforeBraces: Attach
+BraceWrapping:
+  AfterFunction: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterEnum: false
+  AfterExternBlock: false
+  BeforeElse: true
+  IndentBraces: false
+
+PointerAlignment: Left
+SpaceAfterCStyleCast: true
+SpacesBeforeTrailingComments: 1
+
+ConstructorInitializerIndentWidth: 4
+
+SortIncludes: false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig configuration for gtkchart
+# http://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file, utf-8 charset
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Match config files, set indent to spaces with width of eight
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+max_line_length = 109
+
+[meson.build]
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
New `.clang-format` and `.editorconfig` files added as raised in #8 

I will fix the conflict once PR #12  is finished