### PR TITLE
Add support for pie chart

### DIFF
--- a/demo/demo_box.c
+++ b/demo/demo_box.c
@@ -97,6 +97,7 @@ static void demo_box_init(DemoBox *self)
 
     GtkWidget *hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
     GtkWidget *hbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
+    GtkWidget *hbox3 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
 
     // --- Line Chart ---
     GtkChart *line_chart = GTK_CHART(gtk_chart_new());
@@ -151,11 +152,23 @@ static void demo_box_init(DemoBox *self)
     gtk_chart_set_title(number_chart, "Number Chart");
     gtk_widget_set_hexpand(GTK_WIDGET(number_chart), TRUE);
     gtk_widget_set_vexpand(GTK_WIDGET(number_chart), TRUE);
+    gtk_box_append(GTK_BOX(hbox3), GTK_WIDGET(number_chart));
     g_timeout_add(50, number_chart_timeout, number_chart);
+
+    // --- Pie Chart ---
+    GtkChart *pie_chart = GTK_CHART(gtk_chart_new());
+    gtk_chart_set_type(pie_chart, GTK_CHART_TYPE_PIE);
+    gtk_chart_set_title(pie_chart, "Pie Chart");
+    gtk_widget_set_hexpand(GTK_WIDGET(pie_chart), TRUE);
+    gtk_widget_set_vexpand(GTK_WIDGET(pie_chart), TRUE);
+    gtk_chart_add_slice(pie_chart, 50, "#FF6484");
+    gtk_chart_add_slice(pie_chart, 25, "#FFC686");
+    gtk_chart_add_slice(pie_chart, 25, "#36A282");
+    gtk_box_append(GTK_BOX(hbox3), GTK_WIDGET(pie_chart));
 
     gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox1));
     gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox2));
-    gtk_box_append(GTK_BOX(self), GTK_WIDGET(number_chart));
+    gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox3));
 }
 
 static void demo_box_class_init(DemoBoxClass *klass)

--- a/src/gtkchart.c
+++ b/src/gtkchart.c
@@ -1108,3 +1108,44 @@ EXPORT void gtk_chart_set_font(GtkChart *chart, const char *name)
 
     chart->font_name = g_strdup(name);
 }
+
+EXPORT void gtk_chart_set_slice_value(GtkChart *chart, int index, double value)
+{
+  g_assert_nonnull(chart);
+  if(index < 0) return;
+
+  GSList *l = chart->slice_list;
+  int i = 0;
+
+  while(l != NULL && i < index)
+  {
+    l = l->next;
+    i++;
+  }
+
+  if(l == NULL) return;
+
+  struct chart_slice_t *slice = l->data;
+  slice->value = value;
+}
+
+EXPORT bool gtk_chart_set_slice_color(GtkChart *chart, int index, const char *color)
+{
+  g_assert_nonnull(chart);
+  g_assert_nonnull(color);
+  if(index < 0) return false;
+
+  GSList *l = chart->slice_list;
+  int i = 0;
+
+  while(l != NULL && i < index)
+  {
+    l = l->next;
+    i++;
+  }
+
+  if(l == NULL) return false;
+
+  struct chart_slice_t *slice = l->data;
+  return gdk_rgba_parse(&slice->color, color);
+}

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -93,5 +93,7 @@ EXPORT bool gtk_chart_set_color(GtkChart *chart, char *name, char *color);
 EXPORT void gtk_chart_set_font(GtkChart *chart, const char *name);
 
 EXPORT void gtk_chart_add_slice(GtkChart *chart, double value, const char *color);
+EXPORT void gtk_chart_set_slice_value(GtkChart *chart, int index, double value);
+EXPORT bool gtk_chart_set_slice_color(GtkChart *chart, int index, const char *color);
 
 G_END_DECLS

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -57,6 +57,7 @@ typedef enum
   GTK_CHART_TYPE_SCATTER,
   GTK_CHART_TYPE_GAUGE_ANGULAR,
   GTK_CHART_TYPE_GAUGE_LINEAR,
+  GTK_CHART_TYPE_PIE,
   GTK_CHART_TYPE_NUMBER
 } GtkChartType;
 
@@ -90,5 +91,7 @@ EXPORT void * gtk_chart_get_user_data(GtkChart *chart);
 
 EXPORT bool gtk_chart_set_color(GtkChart *chart, char *name, char *color);
 EXPORT void gtk_chart_set_font(GtkChart *chart, const char *name);
+
+EXPORT void gtk_chart_add_slice(GtkChart *chart, double value, const char *color);
 
 G_END_DECLS


### PR DESCRIPTION
- Addded support for pie chart with multiple color slices.

- Added title at the top of the pie chart.

- Added `gtk_chart_set_slice_value` and `gtk_chart_set_slice_color`.

-  Updated the demo to show a example of the pie chart.

<img width="1056" height="888" alt="Captura de ecrã de 2025-07-14 16-34-34" src="https://github.com/user-attachments/assets/4cb5568c-faa8-4492-80a8-2ab163f2fc5b" />





