### PR TITLE
Add pie chart labels & Add support for bar chart

### DIFF
--- a/demo/demo_box.c
+++ b/demo/demo_box.c
@@ -161,9 +161,9 @@ static void demo_box_init(DemoBox *self)
     gtk_chart_set_title(pie_chart, "Pie Chart");
     gtk_widget_set_hexpand(GTK_WIDGET(pie_chart), TRUE);
     gtk_widget_set_vexpand(GTK_WIDGET(pie_chart), TRUE);
-    gtk_chart_add_slice(pie_chart, 50, "#FF6484");
-    gtk_chart_add_slice(pie_chart, 25, "#FFC686");
-    gtk_chart_add_slice(pie_chart, 25, "#36A282");
+    gtk_chart_add_slice(pie_chart, 50, "#FF6484", "Mathematics");
+    gtk_chart_add_slice(pie_chart, 25, "#FFC686", "English");
+    gtk_chart_add_slice(pie_chart, 25, "#36A282", "Science");
     gtk_box_append(GTK_BOX(hbox3), GTK_WIDGET(pie_chart));
 
     gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox1));

--- a/demo/demo_box.c
+++ b/demo/demo_box.c
@@ -98,6 +98,7 @@ static void demo_box_init(DemoBox *self)
     GtkWidget *hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
     GtkWidget *hbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
     GtkWidget *hbox3 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
+    GtkWidget *hbox4 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
 
     // --- Line Chart ---
     GtkChart *line_chart = GTK_CHART(gtk_chart_new());
@@ -135,6 +136,7 @@ static void demo_box_init(DemoBox *self)
     gtk_chart_set_value_max(gauge_angular_chart, 50.0);
     gtk_box_append(GTK_BOX(hbox2), GTK_WIDGET(gauge_angular_chart));
     g_timeout_add(50, angular_gauge_chart_timeout, gauge_angular_chart);
+
     // --- Linear Angular Chart ---
     GtkChart *gauge_linear_chart = GTK_CHART(gtk_chart_new());
     gtk_chart_set_type(gauge_linear_chart, GTK_CHART_TYPE_GAUGE_LINEAR);
@@ -152,7 +154,7 @@ static void demo_box_init(DemoBox *self)
     gtk_chart_set_title(number_chart, "Number Chart");
     gtk_widget_set_hexpand(GTK_WIDGET(number_chart), TRUE);
     gtk_widget_set_vexpand(GTK_WIDGET(number_chart), TRUE);
-    gtk_box_append(GTK_BOX(hbox3), GTK_WIDGET(number_chart));
+    gtk_box_append(GTK_BOX(hbox4), GTK_WIDGET(number_chart));
     g_timeout_add(50, number_chart_timeout, number_chart);
 
     // --- Pie Chart ---
@@ -166,9 +168,22 @@ static void demo_box_init(DemoBox *self)
     gtk_chart_add_slice(pie_chart, 25, "#36A282", "Science");
     gtk_box_append(GTK_BOX(hbox3), GTK_WIDGET(pie_chart));
 
+    // --- Column (Bar) Chart ---
+    GtkChart *column_chart = GTK_CHART(gtk_chart_new());
+    gtk_chart_set_type(column_chart, GTK_CHART_TYPE_COLUMN);
+    gtk_chart_set_title(column_chart, "Column Chart");
+    gtk_widget_set_hexpand(GTK_WIDGET(column_chart), TRUE);
+    gtk_widget_set_vexpand(GTK_WIDGET(column_chart), TRUE);
+    gtk_chart_add_column(GTK_CHART(column_chart), 10, "#3498DB", "Sunday");
+    gtk_chart_add_column(GTK_CHART(column_chart), 4, "#2ECC71", "Monday");
+    gtk_chart_add_column(GTK_CHART(column_chart), 8, "#F1C40F", "Tuesday");
+    gtk_chart_set_column_ticks(GTK_CHART(column_chart), 5);
+    gtk_box_append(GTK_BOX(hbox3), GTK_WIDGET(column_chart));
+
     gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox1));
     gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox2));
     gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox3));
+    gtk_box_append(GTK_BOX(self), GTK_WIDGET(hbox4));
 }
 
 static void demo_box_class_init(DemoBoxClass *klass)

--- a/src/gtkchart.c
+++ b/src/gtkchart.c
@@ -796,8 +796,8 @@ static void chart_draw_column(GtkChart *self,
         return;
     }
 
-    float spacing = (w * 0.05) * (n_total + 1);
-    float column_width = (w - spacing) / n_total;
+    float spacing = (w * 0.05) / (n_total + 1);
+    float column_width = (w - 10 * (w * 0.05) - spacing * (n_total - 1)) / n_total;
 
     double max_value = 0.0;
     GSList *l;
@@ -848,7 +848,7 @@ static void chart_draw_column(GtkChart *self,
 
         float column_height = column->value * y_scale;
 
-        float x = (w * 0.05) + i * (column_width + (w * 0.05));
+        float x = (w * 0.05) + i * (column_width + spacing);
         float y = h - (0.1 * h) - column_height;
         i++;
 
@@ -861,21 +861,22 @@ static void chart_draw_column(GtkChart *self,
         if(column->label != NULL) {
             cairo_text_extents_t extents;
 
-        // Draw Label
-        cairo_set_source_rgba(cr, 0.6, 0.6, 0.6, 0.8);
-        cairo_select_font_face(cr, self->font_name, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-        cairo_set_font_size(cr, 12);
-        cairo_text_extents(cr, column->label, &extents);
+            // Draw Label
+            cairo_set_source_rgba(cr, 0.6, 0.6, 0.6, 0.8);
+            cairo_select_font_face(cr, self->font_name, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+            cairo_set_font_size(cr, 12);
+            cairo_text_extents(cr, column->label, &extents);
 
-        float label_x = x + column_width / 2;
-        float label_y = h - (w * 0.03) + 20;
+            float label_x = x + column_width / 2;
+            float label_y = h - (w * 0.03) + 20;
 
-        cairo_save(cr);
-        cairo_translate(cr, label_x, label_y);
-        cairo_rotate(cr, -M_PI / 3); // rotate -60º (-PI/3)
+            cairo_save(cr);
+            cairo_translate(cr, label_x, label_y);
+            cairo_rotate(cr, -M_PI / 3); // rotate -60º (-PI/3)
 
-        cairo_move_to(cr, -extents.width / 2, -extents.height);
-        cairo_show_text(cr, column->label);
+            cairo_move_to(cr, -extents.width / 2, -extents.height);
+            cairo_show_text(cr, column->label);
+            cairo_restore(cr);
         }
     }
     cairo_destroy(cr);
@@ -1396,4 +1397,11 @@ EXPORT void gtk_chart_set_column_label(GtkChart *chart, int index, const char *l
 
   g_free(column->label);
   column->label = g_strdup(label);
+}
+
+EXPORT void gtk_chart_set_column_ticks(GtkChart *chart, int ticks)
+{
+  g_assert_nonnull(chart);
+
+  chart->ticks = ticks;
 }

--- a/src/gtkchart.c
+++ b/src/gtkchart.c
@@ -49,7 +49,7 @@ struct chart_slice_t
 struct _GtkChart
 {
     GtkWidget parent_instance;
-    int type;
+    GtkChartType type;
     char *title;
     char *label;
     char *x_label;

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -92,8 +92,9 @@ EXPORT void * gtk_chart_get_user_data(GtkChart *chart);
 EXPORT bool gtk_chart_set_color(GtkChart *chart, char *name, char *color);
 EXPORT void gtk_chart_set_font(GtkChart *chart, const char *name);
 
-EXPORT void gtk_chart_add_slice(GtkChart *chart, double value, const char *color);
+EXPORT void gtk_chart_add_slice(GtkChart *chart, double value, const char *color, const char *label);
 EXPORT void gtk_chart_set_slice_value(GtkChart *chart, int index, double value);
 EXPORT bool gtk_chart_set_slice_color(GtkChart *chart, int index, const char *color);
+EXPORT void gtk_chart_set_slice_label(GtkChart *chart, int index, const char *label);
 
 G_END_DECLS

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -103,5 +103,6 @@ EXPORT void gtk_chart_add_column(GtkChart *chart, double value, const char *colo
 EXPORT void gtk_chart_set_column_value(GtkChart *chart, int index, double value);
 EXPORT bool gtk_chart_set_column_color(GtkChart *chart, int index, const char *color);
 EXPORT void gtk_chart_set_column_label(GtkChart *chart, int index, const char *label);
+EXPORT void gtk_chart_set_column_ticks(GtkChart *chart, int ticks);
 
 G_END_DECLS

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -58,6 +58,7 @@ typedef enum
   GTK_CHART_TYPE_GAUGE_ANGULAR,
   GTK_CHART_TYPE_GAUGE_LINEAR,
   GTK_CHART_TYPE_PIE,
+  GTK_CHART_TYPE_COLUMN,
   GTK_CHART_TYPE_NUMBER
 } GtkChartType;
 
@@ -96,5 +97,11 @@ EXPORT void gtk_chart_add_slice(GtkChart *chart, double value, const char *color
 EXPORT void gtk_chart_set_slice_value(GtkChart *chart, int index, double value);
 EXPORT bool gtk_chart_set_slice_color(GtkChart *chart, int index, const char *color);
 EXPORT void gtk_chart_set_slice_label(GtkChart *chart, int index, const char *label);
+
+
+EXPORT void gtk_chart_add_column(GtkChart *chart, double value, const char *color, const char *label);
+EXPORT void gtk_chart_set_column_value(GtkChart *chart, int index, double value);
+EXPORT bool gtk_chart_set_column_color(GtkChart *chart, int index, const char *color);
+EXPORT void gtk_chart_set_column_label(GtkChart *chart, int index, const char *label);
 
 G_END_DECLS

--- a/src/gtkchart.h
+++ b/src/gtkchart.h
@@ -104,5 +104,6 @@ EXPORT void gtk_chart_set_column_value(GtkChart *chart, int index, double value)
 EXPORT bool gtk_chart_set_column_color(GtkChart *chart, int index, const char *color);
 EXPORT void gtk_chart_set_column_label(GtkChart *chart, int index, const char *label);
 EXPORT void gtk_chart_set_column_ticks(GtkChart *chart, int ticks);
+EXPORT double gtk_chart_get_column_max_value(GtkChart *chart);
 
 G_END_DECLS


### PR DESCRIPTION
- Replace int with GtkChartType for type variable. 
- Added pie chart labels and fix position between 90º and 270º.
- Added support for column chart.
- Added gtk_chart_set_collumn_ticks.
- Added gtk_chart_get_column_max_value (useful to set max ticks).
- Update demo example.

<img width="1056" height="888" alt="Captura de ecrã de 2025-07-28 16-57-01" src="https://github.com/user-attachments/assets/e02bd18c-8439-45e0-93d9-c34f88f4ba6f" />
